### PR TITLE
fix shaky column/kanban selection

### DIFF
--- a/frontend/src/components/modal/column/ColumnOptionModal.vue
+++ b/frontend/src/components/modal/column/ColumnOptionModal.vue
@@ -25,13 +25,13 @@
                 :list="cols"
                 :animation="200"
                 ghost-class="ghost-card"
-                group="column.id"
-                id="column"
+                group="col.id"
+                id="col"
               >
                 <ColumnCard
-                  v-for="column in cols"
-                  :key="column.id"
-                  :column="column"
+                  v-for="col in cols"
+                  :key="col.id"
+                  :column="col"
                   @deleteColumn="deleteColumn"
                   @updateColumn="updateColumn"
                   :tryError="invalidColumns"


### PR DESCRIPTION
## Tickets

## Summary Of Changes
- kanban draggable, and column option draggable were sorted on same key, making it possible to drop a column card into the kanban board behind
- This interference also made dragging and dropping columns shaky occasionally
## Notes for Reviewers
