### PR TITLE
Only call get_job_by_id when Required

### DIFF
--- a/frontend/__tests__/JobTrackingView.test.js
+++ b/frontend/__tests__/JobTrackingView.test.js
@@ -143,6 +143,7 @@ describe('JobTrackingView', () => {
       kcolumn_id: 8,
     })
     expect(wrapper.vm.jobsByColumn[8]).toEqual([
+      { id: 0, kcolumn_id: 8 },
       {
         id: 12,
         company: 'Minisoft',
@@ -154,7 +155,6 @@ describe('JobTrackingView', () => {
         description: 'Description',
         notes: 'Test',
       },
-      { id: 0, kcolumn_id: 8 },
     ])
   })
 

--- a/frontend/__tests__/JobTrackingView.test.js
+++ b/frontend/__tests__/JobTrackingView.test.js
@@ -101,11 +101,30 @@ describe('JobTrackingView', () => {
     expect(wrapper.vm.colList).toEqual([{ id: 8 }, { id: 2 }, { id: 1 }])
   })
 
-  it('posts a request to get_job_by_id when job detail opened', async () => {
+  it('doesnt post a request to get_job_by_id when job detail opened with complete job', async () => {
     await wrapper.vm.showDetailModal(testJobs[1])
 
-    expect(postRequest).toHaveBeenCalledWith('job/api/get_job_by_id', {
+    expect(postRequest).not.toHaveBeenCalledWith('job/api/get_job_by_id', {
       job_id: testJobs[1].id,
+      user_id: mockuser.id,
+    })
+
+    expect(wrapper.vm.selectedJob).toEqual(testJobs[1])
+    expect(wrapper.vm.detailModalVisible).toBe(true)
+  })
+
+  it('posts a request to get_job_by_id when job detail opened with minimal job', async () => {
+    let minimalJob = {
+      id: 10,
+      company: 'Wework',
+      type: 'Backend',
+      position: 'Software Engineer I',
+      kcolumn_id: 1,
+    }
+    await wrapper.vm.showDetailModal(minimalJob)
+
+    expect(postRequest).toHaveBeenCalledWith('job/api/get_job_by_id', {
+      job_id: minimalJob.id,
       user_id: mockuser.id,
     })
 

--- a/frontend/src/views/JobTrackingView.vue
+++ b/frontend/src/views/JobTrackingView.vue
@@ -158,13 +158,19 @@ export default {
     async showDetailModal(job) {
       if (job) {
         // editing job
-        await postRequest('job/api/get_job_by_id', {
-          user_id: this.activeUser.id,
-          job_id: job.id,
-        }).then((completeJob) => {
-          this.selectedJob = completeJob.job_data
+        if (!job.deadlines) {
+          // only get from backend if job not populated
+          await postRequest('job/api/get_job_by_id', {
+            user_id: this.activeUser.id,
+            job_id: job.id,
+          }).then((completeJob) => {
+            this.selectedJob = completeJob.job_data
+            this.detailModalVisible = true
+          })
+        } else {
+          this.selectedJob = job
           this.detailModalVisible = true
-        })
+        }
       } else {
         // creating new job
         isNewJob.value = true

--- a/frontend/src/views/JobTrackingView.vue
+++ b/frontend/src/views/JobTrackingView.vue
@@ -159,7 +159,7 @@ export default {
     async showDetailModal(job) {
       if (job) {
         // editing job
-        if (!job.deadlines) {
+        if (job.deadlines === undefined) {
           // only get from backend if job not populated
           await postRequest('job/api/get_job_by_id', {
             user_id: this.activeUser.id,

--- a/frontend/src/views/JobTrackingView.vue
+++ b/frontend/src/views/JobTrackingView.vue
@@ -124,6 +124,7 @@ export default {
         userJob.user_id = this.activeUser.id
         await postRequest('job/api/create_job', userJob).then((newJob) => {
           isNewJob.value = false
+          // Push New Job To Bottom of Column
           jobsByColumn.value[newJob.job.kcolumn_id].push(newJob.job)
         })
       } else {
@@ -135,9 +136,12 @@ export default {
             ].filter((item) => item.id !== job.id)
           }
         })
-        await postRequest('job/api/update_job', job).then(
-          jobsByColumn.value[job.kcolumn_id].push(job),
-        )
+        await postRequest('job/api/update_job', job).then(() => {
+          jobsByColumn.value[job.kcolumn_id].push(job)
+          jobsByColumn.value[job.kcolumn_id] = jobsByColumn.value[
+            job.kcolumn_id
+          ].sort((a, b) => a.id - b.id)
+        })
       }
     },
     async updateColumns(columns) {
@@ -169,6 +173,10 @@ export default {
               job.kcolumn_id
             ].filter((item) => item.id !== job.id)
             jobsByColumn.value[job.kcolumn_id].push(completeJob.job_data)
+
+            jobsByColumn.value[job.kcolumn_id] = jobsByColumn.value[
+              job.kcolumn_id
+            ].sort((a, b) => a.id - b.id)
 
             this.selectedJob = completeJob.job_data
             this.detailModalVisible = true

--- a/frontend/src/views/JobTrackingView.vue
+++ b/frontend/src/views/JobTrackingView.vue
@@ -135,8 +135,9 @@ export default {
             ].filter((item) => item.id !== job.id)
           }
         })
-        await postRequest('job/api/update_job', job)
-        jobsByColumn.value[job.kcolumn_id].push(job)
+        await postRequest('job/api/update_job', job).then(
+          jobsByColumn.value[job.kcolumn_id].push(job),
+        )
       }
     },
     async updateColumns(columns) {
@@ -164,6 +165,11 @@ export default {
             user_id: this.activeUser.id,
             job_id: job.id,
           }).then((completeJob) => {
+            jobsByColumn.value[job.kcolumn_id] = jobsByColumn.value[
+              job.kcolumn_id
+            ].filter((item) => item.id !== job.id)
+            jobsByColumn.value[job.kcolumn_id].push(completeJob.job_data)
+
             this.selectedJob = completeJob.job_data
             this.detailModalVisible = true
           })


### PR DESCRIPTION
## Tickets
Closes #82 
## Summary Of Changes
- Added check in `showDetailModal` which looks at whether the job being opened is populated with only minimum fields or if complete object exists
- Only calls backend `get_job_by_id` when job is minimally populated
## Notes for Reviewers
- Open up the network devtools tab and verify that `get_job_by_id` is only called when clicking on a job card for the first time
  - newly created jobs are fully populated in the frontend, so clicking the card for a job created in the same session should not post to backend