### PR TITLE
Unique Factory Fields

### DIFF
--- a/backend/account/tests/factories.py
+++ b/backend/account/tests/factories.py
@@ -7,9 +7,9 @@ class UserFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = User
 
-    id = factory.Faker("localized_ean8")
+    id = factory.Faker("localized_ean13")
     first_name = factory.Faker("first_name")
     last_name = factory.Faker("last_name")
-    username = factory.Faker("domain_word")
+    username = factory.Sequence(lambda n: "username%d" % n)
     email = factory.Faker("ascii_safe_email")
-    google_id = factory.Faker("localized_ean8")
+    google_id = factory.Faker("localized_ean13")

--- a/backend/account/tests/factories.py
+++ b/backend/account/tests/factories.py
@@ -7,7 +7,7 @@ class UserFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = User
 
-    id = factory.Faker("localized_ean13")
+    id = factory.Sequence(lambda n: n)
     first_name = factory.Faker("first_name")
     last_name = factory.Faker("last_name")
     username = factory.Sequence(lambda n: "username%d" % n)

--- a/backend/job/tests/factories.py
+++ b/backend/job/tests/factories.py
@@ -9,7 +9,7 @@ class JobFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = Job
 
-    id = factory.Faker("localized_ean8")
+    id = factory.Faker("localized_ean13")
     kcolumn = factory.SubFactory(KanbanColumnFactory)
     user = factory.SubFactory(UserFactory)
     position_title = "Position"

--- a/backend/job/tests/factories.py
+++ b/backend/job/tests/factories.py
@@ -9,7 +9,7 @@ class JobFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = Job
 
-    id = factory.Faker("localized_ean13")
+    id = factory.Sequence(lambda n: n)
     kcolumn = factory.SubFactory(KanbanColumnFactory)
     user = factory.SubFactory(UserFactory)
     position_title = "Position"


### PR DESCRIPTION
## Tickets
Closes #123 
## Summary Of Changes
- Make `id` fields & `username` auto-incrementing to avoid non-unique conflicts
- Make `google_id` 13 digits
## Notes for Reviewers
- We could make `google_id ` field auto-increment and make them 100% conflict free, so open to suggestions, but the odds of conflicts with 13 digit numbers is pretty tiny, and 13 digits is a more realistic `google_id` than a single digit auto-incrementing/predictable value