### PR TITLE
Catch Auth Error

### DIFF
--- a/frontend/__tests__/MainView.test.js
+++ b/frontend/__tests__/MainView.test.js
@@ -77,6 +77,21 @@ describe('MainView', () => {
     )
   })
 
+  it('catches Error when auth_token validation fails', async () => {
+    getAuthToken.mockReturnValue('token')
+    postRequest.mockReturnValue(Error())
+    const warnSpy = vi.spyOn(console, 'warn')
+    shallowMount(MainView)
+    flushPromises()
+
+    expect(postRequest).toHaveBeenCalledWith(
+      'account/api/validate_auth_token',
+      'token',
+    )
+
+    expect(warnSpy).toBeCalledWith('Token Authentication Failed')
+  })
+
   it('logs out when logoutClicked', () => {
     const wrapper = shallowMount(MainView)
     delete window.location

--- a/frontend/src/views/MainView.vue
+++ b/frontend/src/views/MainView.vue
@@ -72,13 +72,18 @@ export default {
   async mounted() {
     let token = getAuthToken()
     if (token) {
-      await postRequest('account/api/validate_auth_token', token).then(
-        (response) => {
-          if (response.user) {
-            this.userSignedIn({ data: response.user, token: response.token })
-          }
-        },
-      )
+      try {
+        await postRequest('account/api/validate_auth_token', token).then(
+          (response) => {
+            if (response.user) {
+              this.userSignedIn({ data: response.user, token: response.token })
+            }
+          },
+        )
+      } catch (error) {
+        // eslint-disable-next-line no-console
+        console.warn('Token Authentication Failed')
+      }
     }
     if (!this.userData) this.failedAuthentication = true
   },


### PR DESCRIPTION
## Tickets
Closes #130 
## Summary Of Changes
- `requests.js` throws an error when non-200 received, catch this error as it's expected when authentication fails
## Notes for Testing
- Login -> flush db -> refresh page
  - Login screen should re-appear (previously page broke)