### PR TITLE
Long single-word cover letter

### DIFF
--- a/frontend/src/components/modal/job/ReviewModal.vue
+++ b/frontend/src/components/modal/job/ReviewModal.vue
@@ -12,7 +12,7 @@
         </v-card-title>
         <v-card-text>
           <div style="display: flex">
-            <v-col>
+            <v-col style="width: 37vw">
               {{ jobData?.cover_letter }}
             </v-col>
             <v-col>


### PR DESCRIPTION
## Tickets
Closes #164 
## Summary Of Changes
When a cover letter is a (long) single word the review modal appeared like this:
![Screenshot 2023-03-23 at 7 13 23 PM](https://user-images.githubusercontent.com/76849108/227391614-6c284c8c-5423-45dd-a5f5-71bb1cdaebf1.png)

Now displays like:
![Screenshot 2023-03-23 at 7 18 04 PM](https://user-images.githubusercontent.com/76849108/227392130-e616342b-d3c2-4004-a343-225e0d7f8f38.png)

## Notes for Reviewers

